### PR TITLE
Allow more extensions for served Javascript files

### DIFF
--- a/serve.ts
+++ b/serve.ts
@@ -43,7 +43,7 @@ const serveFile = async (req: Request): Promise<Response> => {
 
   const contentType = path.endsWith(".html")
     ? "text/html"
-    : path.endsWith(".js")
+    : !!path.match(/\.(js|es|mjs)$/)
     ? "text/javascript"
     : path.endsWith(".css")
     ? "text/css"


### PR DESCRIPTION
This will allow these file extensions to be served as `text/javascript`
- `.js`
- `.es`
- `.mjs`